### PR TITLE
feat: protection anti-bot formulaires inscription

### DIFF
--- a/src/controllers/inscriptionController.js
+++ b/src/controllers/inscriptionController.js
@@ -188,6 +188,9 @@ const inscriptionController = {
             // Récupérer les pré-inscriptions ET les dossiers d'inscription
             const [preInscriptions, dossierInscriptions] = await Promise.all([
                 prisma.preInscriptionRequest.findMany({
+                    where: {
+                        NOT: { status: 'EMAIL_PENDING' }
+                    },
                     orderBy: { submittedAt: 'desc' },
                     include: { processor: true }
                 }),

--- a/src/middleware/publicFormProtection.js
+++ b/src/middleware/publicFormProtection.js
@@ -1,0 +1,101 @@
+const spamDetector = require('./spamDetector');
+const LoggingService = require('../services/loggingService');
+
+const toIntOrNull = (value) => {
+    if (value === null || value === undefined) return null;
+    const n = parseInt(value, 10);
+    return Number.isFinite(n) ? n : null;
+};
+
+const safeBodySnapshot = (body) => {
+    if (!body || typeof body !== 'object') return {};
+
+    const snapshot = {
+        parentEmail: body.parentEmail || body.email || null,
+        parentFirstName: body.parentFirstName || body.firstName || null,
+        parentLastName: body.parentLastName || body.lastName || null,
+        parentPhone: body.parentPhone || body.phone || null,
+        anneeScolaire: body.anneeScolaire || null
+    };
+
+    if (body.children) {
+        if (Array.isArray(body.children)) snapshot.childrenCount = body.children.length;
+        else if (typeof body.children === 'object') snapshot.childrenCount = Object.keys(body.children).length;
+    }
+
+    return snapshot;
+};
+
+const shouldBlockFromReasons = (reasons) => {
+    const text = (reasons || []).join(' | ').toLowerCase();
+
+    // Raisons « fortes » => blocage
+    return (
+        text.includes('honeypot') ||
+        text.includes('trop de requêtes') ||
+        text.includes('rempli trop rapidement') ||
+        text.includes('email suspect')
+    );
+};
+
+const createSpamProtection = ({ endpoint, mode, redirectTo }) => {
+    return (req, res, next) => {
+        const formStartTime =
+            toIntOrNull(req.body?.formStartTime) ??
+            toIntOrNull(req.body?.formStart) ??
+            toIntOrNull(req.body?.formStartTimeMs);
+
+        const detection = spamDetector.detectSpam(req, formStartTime);
+        req.spamDetection = detection;
+
+        if (!detection.isSpam) return next();
+
+        const bodySnapshot = safeBodySnapshot(req.body);
+
+        setImmediate(() => {
+            LoggingService.logAction(req, 'spam_detected', {
+                route: endpoint,
+                errorMessage: JSON.stringify({
+                    riskLevel: detection.riskLevel,
+                    reasons: detection.reasons,
+                    body: bodySnapshot
+                }),
+                userEmail: bodySnapshot.parentEmail || null
+            }).catch(console.error);
+        });
+
+        if (!shouldBlockFromReasons(detection.reasons)) {
+            return next();
+        }
+
+        const message = 'Votre demande a été temporairement bloquée (protection anti-bot). Veuillez réessayer dans quelques minutes.';
+
+        setImmediate(() => {
+            LoggingService.logAction(req, 'spam_blocked', {
+                route: endpoint,
+                errorMessage: JSON.stringify({
+                    riskLevel: detection.riskLevel,
+                    reasons: detection.reasons,
+                    body: bodySnapshot
+                }),
+                userEmail: bodySnapshot.parentEmail || null
+            }).catch(console.error);
+        });
+
+        if (mode === 'query' && redirectTo) {
+            const sep = redirectTo.includes('?') ? '&' : '?';
+            return res.status(429).redirect(`${redirectTo}${sep}error=${encodeURIComponent(message)}`);
+        }
+
+        if (req.flash && redirectTo) {
+            req.flash('error', message);
+            return res.status(429).redirect(redirectTo);
+        }
+
+        return res.status(429).send(message);
+    };
+};
+
+module.exports = {
+    createSpamProtection
+};

--- a/src/middleware/rateLimiters.js
+++ b/src/middleware/rateLimiters.js
@@ -1,0 +1,99 @@
+const rateLimit = require('express-rate-limit');
+const LoggingService = require('../services/loggingService');
+
+const createFormLimiter = ({
+    endpoint,
+    windowMs,
+    max,
+    message,
+    mode,
+    redirectTo
+}) => {
+    return rateLimit({
+        windowMs,
+        max,
+        standardHeaders: true,
+        legacyHeaders: false,
+        keyGenerator: (req, res) => rateLimit.ipKeyGenerator(req, res),
+        handler: (req, res) => {
+            setImmediate(() => {
+                LoggingService.logAction(req, 'rate_limited', {
+                    route: endpoint,
+                    errorMessage: `Rate limit hit: ${max} per ${Math.round(windowMs / 1000)}s`,
+                    userEmail: req.body?.parentEmail || req.body?.email || null
+                }).catch(console.error);
+            });
+
+            const safeMessage = message || 'Trop de requêtes. Veuillez réessayer dans quelques minutes.';
+
+            if (mode === 'query' && redirectTo) {
+                const sep = redirectTo.includes('?') ? '&' : '?';
+                return res.status(429).redirect(`${redirectTo}${sep}error=${encodeURIComponent(safeMessage)}`);
+            }
+
+            if (req.flash && redirectTo) {
+                req.flash('error', safeMessage);
+                return res.status(429).redirect(redirectTo);
+            }
+
+            return res.status(429).send(safeMessage);
+        }
+    });
+};
+
+const inscriptionEleveBurstLimiter = createFormLimiter({
+    endpoint: 'POST /inscription-eleve (burst)',
+    windowMs: 5 * 60 * 1000,
+    max: 8,
+    mode: 'flash',
+    redirectTo: '/inscription-eleve'
+});
+
+const inscriptionEleveHourlyLimiter = createFormLimiter({
+    endpoint: 'POST /inscription-eleve (hourly)',
+    windowMs: 60 * 60 * 1000,
+    max: 25,
+    mode: 'flash',
+    redirectTo: '/inscription-eleve'
+});
+
+const preInscriptionBurstLimiter = createFormLimiter({
+    endpoint: 'POST /pre-inscription (burst)',
+    windowMs: 5 * 60 * 1000,
+    max: 8,
+    mode: 'flash',
+    redirectTo: '/pre-inscription'
+});
+
+const preInscriptionHourlyLimiter = createFormLimiter({
+    endpoint: 'POST /pre-inscription (hourly)',
+    windowMs: 60 * 60 * 1000,
+    max: 25,
+    mode: 'flash',
+    redirectTo: '/pre-inscription'
+});
+
+const authRegisterBurstLimiter = createFormLimiter({
+    endpoint: 'POST /auth/register (burst)',
+    windowMs: 5 * 60 * 1000,
+    max: 6,
+    mode: 'query',
+    redirectTo: '/auth/register'
+});
+
+const authRegisterHourlyLimiter = createFormLimiter({
+    endpoint: 'POST /auth/register (hourly)',
+    windowMs: 60 * 60 * 1000,
+    max: 20,
+    mode: 'query',
+    redirectTo: '/auth/register'
+});
+
+module.exports = {
+    inscriptionEleveBurstLimiter,
+    inscriptionEleveHourlyLimiter,
+    preInscriptionBurstLimiter,
+    preInscriptionHourlyLimiter,
+    authRegisterBurstLimiter,
+    authRegisterHourlyLimiter
+};

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -3,6 +3,11 @@ const loginRoutes = require('./loginRoutes');
 const passwordResetRoutes = require('./passwordResetRoutes');
 const parentInvitationController = require('../controllers/parentInvitationController');
 const inscriptionController = require('../controllers/inscriptionController');
+const {
+    authRegisterBurstLimiter,
+    authRegisterHourlyLimiter
+} = require('../middleware/rateLimiters');
+const { createSpamProtection } = require('../middleware/publicFormProtection');
 
 const router = express.Router();
 
@@ -11,7 +16,17 @@ router.use('/', passwordResetRoutes); // Routes pour forgot-password et reset-pa
 
 // Routes pour l'inscription publique
 router.get('/register', inscriptionController.showRegistrationForm);
-router.post('/register', inscriptionController.processRegistration);
+router.post(
+    '/register',
+    authRegisterBurstLimiter,
+    authRegisterHourlyLimiter,
+    createSpamProtection({
+        endpoint: 'POST /auth/register',
+        mode: 'query',
+        redirectTo: '/auth/register'
+    }),
+    inscriptionController.processRegistration
+);
 
 // router.use('/register', registerRoutes); // Fichier non existant
 

--- a/src/routes/homeRoutes.js
+++ b/src/routes/homeRoutes.js
@@ -5,13 +5,28 @@ const legalController = require('../controllers/legalController');
 const inscriptionEleveController = require('../controllers/inscriptionEleveController');
 const credentialsController = require('../controllers/credentialsController');
 const { requireAdmin } = require('../middleware/auth');
+const {
+    inscriptionEleveBurstLimiter,
+    inscriptionEleveHourlyLimiter
+} = require('../middleware/rateLimiters');
+const { createSpamProtection } = require('../middleware/publicFormProtection');
 const router = express.Router();
 
 router.get('/', homeController.getHome);
 router.get('/ogec', ogecController.getOgec);
 router.get('/gestion-ecole', ogecController.getOgec);  // Nouvelle route pour test
 router.get('/inscription-eleve', inscriptionEleveController.getInscriptionEleve);
-router.post('/inscription-eleve', inscriptionEleveController.postInscriptionEleve);
+router.post(
+    '/inscription-eleve',
+    inscriptionEleveBurstLimiter,
+    inscriptionEleveHourlyLimiter,
+    createSpamProtection({
+        endpoint: 'POST /inscription-eleve',
+        mode: 'flash',
+        redirectTo: '/inscription-eleve'
+    }),
+    inscriptionEleveController.postInscriptionEleve
+);
 router.post('/admin/inscription-eleve/respond', requireAdmin, inscriptionEleveController.handleDirectorResponse);
 
 // Routes pour demandes d'identifiants

--- a/src/routes/preInscriptionRoutes.js
+++ b/src/routes/preInscriptionRoutes.js
@@ -2,11 +2,26 @@ const express = require('express');
 const preInscriptionController = require('../controllers/preInscriptionController');
 const inscriptionEleveController = require('../controllers/inscriptionEleveController'); // Ajouter pour validation email
 const { requireDirection, requireAdmin } = require('../middleware/auth');
+const {
+    preInscriptionBurstLimiter,
+    preInscriptionHourlyLimiter
+} = require('../middleware/rateLimiters');
+const { createSpamProtection } = require('../middleware/publicFormProtection');
 const router = express.Router();
 
 // Routes publiques pour la pré-inscription
 router.get('/', preInscriptionController.getPreInscription);
-router.post('/', preInscriptionController.postPreInscription);
+router.post(
+    '/',
+    preInscriptionBurstLimiter,
+    preInscriptionHourlyLimiter,
+    createSpamProtection({
+        endpoint: 'POST /pre-inscription',
+        mode: 'flash',
+        redirectTo: '/pre-inscription'
+    }),
+    preInscriptionController.postPreInscription
+);
 
 // ✉️ NOUVELLE ROUTE - Validation email d'inscription (publique)
 router.get('/validate-email/:token', inscriptionEleveController.validateEmail);

--- a/src/views/pages/admin/inscription-requests.twig
+++ b/src/views/pages/admin/inscription-requests.twig
@@ -12,7 +12,7 @@
 				{% set approvedCount = 0 %}
 				{% set rejectedCount = 0 %}
 				{% for request in requests %}
-					{% if request.status == 'PENDING' or request.status == 'EN_ATTENTE' or request.status == 'EMAIL_PENDING' %}
+					{% if request.status == 'PENDING' or request.status == 'EN_ATTENTE' %}
 						{% set pendingCount = pendingCount + 1 %}
 					{% elseif request.status == 'ACCEPTED' or request.status == 'VALIDE' or request.status == 'APPROVED' %}
 						{% set approvedCount = approvedCount + 1 %}
@@ -75,7 +75,7 @@
 						</div>
 
 						<div class="text-right">
-							{% if request.status == 'PENDING' or request.status == 'EN_ATTENTE' or request.status == 'EMAIL_PENDING' %}
+					{% if request.status == 'PENDING' or request.status == 'EN_ATTENTE' %}
 								<span class="badge badge-warning badge-lg">En attente</span>
 							{% elseif request.status == 'ACCEPTED' or request.status == 'VALIDE' or request.status == 'APPROVED' %}
 								<span class="badge badge-success badge-lg">Approuvée</span>
@@ -194,7 +194,7 @@
 							Voir détails
 						</button>
 
-						{% if request.status == 'PENDING' or request.status == 'EN_ATTENTE' or request.status == 'EMAIL_PENDING' %}
+					{% if request.status == 'PENDING' or request.status == 'EN_ATTENTE' %}
 							<button class="btn btn-error" onclick="showRejectModal({{ request.id }})">
 								Refuser
 							</button>
@@ -575,7 +575,7 @@ if (status === 'all') {
 item.style.display = 'block';
 } else {
 const itemStatus = item.dataset.status;
-const show = (status === 'pending' && ['PENDING', 'EN_ATTENTE', 'EMAIL_PENDING'].includes(itemStatus)) || (status === 'approved' && ['ACCEPTED', 'VALIDE', 'APPROVED'].includes(itemStatus)) || (status === 'rejected' && ['REJECTED', 'REFUSE'].includes(itemStatus));
+const show = (status === 'pending' && ['PENDING', 'EN_ATTENTE'].includes(itemStatus)) || (status === 'approved' && ['ACCEPTED', 'VALIDE', 'APPROVED'].includes(itemStatus)) || (status === 'rejected' && ['REJECTED', 'REFUSE'].includes(itemStatus));
 item.style.display = show ? 'block' : 'none';
 }
 });

--- a/src/views/pages/inscription-eleve.twig
+++ b/src/views/pages/inscription-eleve.twig
@@ -465,7 +465,32 @@
 								
 							</ul>
 						</div>
+					<!-- Champs anti-spam cachés (honeypots) -->
+					<div style="position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden;">
+						<label for="floflo">Ne pas remplir ce champ</label>
+						<input type="text" id="floflo" name="floflo" tabindex="-1" autocomplete="off">
 
+						<label for="website">Site web</label>
+						<input type="text" id="website" name="website" tabindex="-1" autocomplete="off">
+
+						<label for="homepage">Page d'accueil</label>
+						<input type="text" id="homepage" name="homepage" tabindex="-1" autocomplete="off">
+
+						<label for="url">URL</label>
+						<input type="text" id="url" name="url" tabindex="-1" autocomplete="off">
+
+						<label for="business">Entreprise</label>
+						<input type="text" id="business" name="business" tabindex="-1" autocomplete="off">
+
+						<label for="company">Société</label>
+						<input type="text" id="company" name="company" tabindex="-1" autocomplete="off">
+					</div>
+
+					<!-- Horodatage pour validation temporelle -->
+					<input type="hidden" id="formStartTime" name="formStartTime" value="">
+					<script>
+						document.getElementById('formStartTime').value = Date.now();
+					</script>
 						<!-- Bouton de soumission -->
 						<div class="text-center pt-8">
 							<div class="relative">

--- a/src/views/pages/pre-inscription.twig
+++ b/src/views/pages/pre-inscription.twig
@@ -35,6 +35,33 @@
 					<form
 						action="/pre-inscription" method="POST" class="space-y-6">
 
+						<!-- Champs anti-spam cachés (honeypots) -->
+						<div style="position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden;">
+							<label for="floflo">Ne pas remplir ce champ</label>
+							<input type="text" id="floflo" name="floflo" tabindex="-1" autocomplete="off">
+
+							<label for="website">Site web</label>
+							<input type="text" id="website" name="website" tabindex="-1" autocomplete="off">
+
+							<label for="homepage">Page d'accueil</label>
+							<input type="text" id="homepage" name="homepage" tabindex="-1" autocomplete="off">
+
+							<label for="url">URL</label>
+							<input type="text" id="url" name="url" tabindex="-1" autocomplete="off">
+
+							<label for="business">Entreprise</label>
+							<input type="text" id="business" name="business" tabindex="-1" autocomplete="off">
+
+							<label for="company">Société</label>
+							<input type="text" id="company" name="company" tabindex="-1" autocomplete="off">
+						</div>
+
+						<!-- Horodatage pour validation temporelle -->
+						<input type="hidden" id="formStartTime" name="formStartTime" value="">
+						<script>
+							document.getElementById('formStartTime').value = Date.now();
+						</script>
+
 						<!-- Section Parent/Responsable -->
 						<div class="border-b border-gray-200 pb-6">
 							<h2 class="text-2xl font-semibold text-[#304a4d] mb-4">


### PR DESCRIPTION
- Rate limiting: 8 req/5min + 25 req/hr par IP (inscription-eleve, pre-inscription, register)
- SpamDetector actif: honeypots, timing, patterns, User-Agent
- Logs dans SiteLog (actions: rate_limited, spam_detected, spam_blocked)
- Masquer demandes EMAIL_PENDING dans interface directeur (donnees conservees en BDD)
- Honeypots + formStartTime dans les formulaires publics inscription-eleve et pre-inscription